### PR TITLE
Update hs-notice.php to fix 2 annoying notices under WP 4.2.x and later

### DIFF
--- a/hs-notice.php
+++ b/hs-notice.php
@@ -16,8 +16,9 @@ class WPHubspotNotice {
 	// Add Configuration Warning
 	//=============================================	
 	function configuration_warning(){
-                $hs_settings = get_option('hs_settings');
-		if(!WPHubspot::hs_is_customer($hs_settings['hs_portal'], $hs_settings['hs_appdomain'])){
+		global $myhubspotwp;
+        	$hs_settings = get_option('hs_settings');
+		if(!$myhubspotwp->hs_is_customer($hs_settings['hs_portal'], $hs_settings['hs_appdomain'])){
                     if(!$hs_settings['hs_config_notice']){
                         if(!(isset($_GET['page']) && $_GET['page'] == 'hubspot_settings')){
                             $this->admin_notice('configuration-warning',10);


### PR DESCRIPTION
Fixes these two notices that appear under WordPress 4.2.x and later:

Notice: Undefined index: page in /Users/???/Sites/???/wp-content/plugins/hubspot/inc/hs-notice.php on line 20

Strict Standards: Non-static method WPHubspot::hs_is_customer() should not be called statically, assuming $this from incompatible context in /Users/???/Sites/???/wp-content/plugins/hubspot/inc/hs-notice.php on line 23

In the version of hs-notice that also has this line:

```
    if ( $_GET['page'] != 'hubspot_activate')
```

change it to:

```
    if (!empty($_GET['page']) && $_GET['page'] != 'hubspot_activate')
```

Cheers!

-Lorin
